### PR TITLE
Added Nextcord requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,4 @@ requests==2.25.1
 typing-extensions==3.7.4.3
 urllib3==1.26.4
 yarl==1.6.3
+nextcord==2.2.0


### PR DESCRIPTION
Because of deprecation issues of discord.py, Nextcord version 2.0.2 is needed to run the bot on a local instance.